### PR TITLE
Documentation refresh after the migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-![CI](https://github.com/gitkent/helm-charts/actions/workflows/ci.yaml/badge.svg)
+![CI](https://github.com/wiremock/helm-charts/actions/workflows/ci.yaml/badge.svg)
 
-# helm-charts
-Helm Chart for deployment to Kubernetes.
+# WireMock Helm Charts
+
+Helm Chart for WireMock deployment to Kubernetes.
 
 # Quick Start
+
 ## Pre-requisites
-1. [Install minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
-2. [Install helm](https://helm.sh/docs/intro/install/)
-3. Deploy Wiremock
-    ```bash
-    helm upgrade --install <release_name> ./chart/<chart_name>
-    ```
+
+1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or use another Kubernetes cluster
+2. [Install Helm](https://helm.sh/docs/intro/install/)
+
+## Install WireMock
+
+```bash
+helm upgrade --install <release_name> ./chart/<chart_name>
+```
+
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 # WireMock Helm Charts
 
 Helm Chart for WireMock deployment to Kubernetes.
+It allows deploying the official [WireMock Docker images](https://github.com/wiremock/wiremock-docker)
+and also other charts that extend it,
+in particular [holomekc/wiremock](https://github.com/holomekc/wiremock) with embedded UI.
 
 # Quick Start
 
@@ -17,4 +20,27 @@ Helm Chart for WireMock deployment to Kubernetes.
 helm upgrade --install <release_name> ./chart/<chart_name>
 ```
 
+Setup port forwarding
+
+```bash
+$ export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "wiremock.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+
+$ kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort}}
+```
+
+## Verify Wiremock deployment
+
+To verify erifying a response using Wiremock, run
+
+```bash
+$ curl -X POST http://127.0.0.1:8080/v1/hello
+```
+
+To check the web app when using `holomekc/wiremock`, visit http://127.0.0.1:8080/__admin/webapp on your browser.
+    
+# References:
+
+- [WireMock Java Library](https://github.com/tomakehurst/wiremock)
+- [Official WireMock Docker Image](https://github.com/wiremock/wiremock-docker)
+- [WireMock extended with Web UI](https://github.com/holomekc/wiremock), a project by [(@holomekc]https://github.com/holomekc)
 

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -3,3 +3,8 @@ appVersion: "2.32.0.2"
 description: A Helm chart for WireMock deployment on Kubernetes
 name: wiremock
 version: 0.1.4
+maintainers:
+  - name: "kent.io"
+    url: "https://github.com/gitkent"
+  - name: "Oleg Nenashev"
+    url: "https://github.com/oleg-nenashev"

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "2.32.0.2"
 description: A Helm chart for WireMock deployment on Kubernetes
 name: wiremock
-version: 0.1.3
+version: 0.1.4

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -4,9 +4,9 @@ description: A Helm chart for WireMock deployment on Kubernetes
 name: wiremock
 version: 0.1.4
 maintainers:
-  - name: "Kent Lee"
+  - name: "gitkent"
     url: "https://github.com/gitkent"
-  - name: "Oleg Nenashev"
+  - name: "oleg-nenashev"
     url: "https://github.com/oleg-nenashev"
 icon: "https://wiremock.org/images/logos/wiremock/logo_square.svg"
 home: "https://wiremock.org"

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -8,3 +8,16 @@ maintainers:
     url: "https://github.com/gitkent"
   - name: "Oleg Nenashev"
     url: "https://github.com/oleg-nenashev"
+icon: "https://wiremock.org/images/logos/wiremock/logo_square.svg"
+home: "https://wiremock.org"
+sources:
+  - "https://github.com/wiremock/helm-charts"
+  - "https://github.com/wiremock/wiremock-docker"
+  - "https://github.com/wiremock/wiremock"  
+keywords:
+  - wiremock
+  - api
+  - openapi
+  - api-testing
+  - rest-api
+  - api-mocking

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "2.32.0.2"
-description: A Helm chart for Wiremock deployment on Kubernetes
+description: A Helm chart for WireMock deployment on Kubernetes
 name: wiremock
 version: 0.1.3

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for WireMock deployment on Kubernetes
 name: wiremock
 version: 0.1.4
 maintainers:
-  - name: "kent.io"
+  - name: "Kent Lee"
     url: "https://github.com/gitkent"
   - name: "Oleg Nenashev"
     url: "https://github.com/oleg-nenashev"
@@ -13,7 +13,7 @@ home: "https://wiremock.org"
 sources:
   - "https://github.com/wiremock/helm-charts"
   - "https://github.com/wiremock/wiremock-docker"
-  - "https://github.com/wiremock/wiremock"  
+  - "https://github.com/wiremock/wiremock"
 keywords:
   - wiremock
   - api

--- a/charts/wiremock/README.md
+++ b/charts/wiremock/README.md
@@ -1,26 +1,45 @@
 # wiremock-helm
-Helm Chart for deployment Wiremock to Kubernetes
+
+Helm Chart for WireMock deployment to Kubernetes.
+It allows deploying the official [WireMock Docker images](https://github.com/wiremock/wiremock-docker)
+and also other charts that extend it,
+in particular [holomekc/wiremock](https://github.com/holomekc/wiremock) with embedded UI.
 
 # Quick Start
+
 ## Pre-requisites
-1. [Install minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
+
+1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
 2. [Install helm](https://helm.sh/docs/intro/install/)
-3. Deploy Wiremock
-    ```bash
-    helm upgrade --install wiremock ./charts/wiremock
-    ```
-4. Verify Wiremock deployment
-    ```bash
-    $ export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "wiremock.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
 
-    $ kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort}}
-    ```
-    Visit http://127.0.0.1:8080/__admin/webapp on your browser.
-5. Verifying a response using Wiremock, run
-    ```
-    $ curl -X POST http://127.0.0.1:8080/v1/hello
-    ```
+## Deploy WireMock
 
+Install WireMock using the Helm chart
+
+```bash
+helm upgrade --install wiremock ./charts/wiremock
+```
+
+Setup port forwarding
+
+```bash
+$ export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "wiremock.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+
+$ kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort}}
+```
+
+## Verify Wiremock deployment
+
+To verify erifying a response using Wiremock, run
+
+```bash
+$ curl -X POST http://127.0.0.1:8080/v1/hello
+```
+
+To check the web app when using `holomekc/wiremock`, visit http://127.0.0.1:8080/__admin/webapp on your browser.
+    
 # References:
-* https://github.com/holomekc/wiremock
-* https://github.com/tomakehurst/wiremock
+
+- [WireMock Java Library](https://github.com/tomakehurst/wiremock)
+- [Official WireMock Docker Image](https://github.com/wiremock/wiremock-docker)
+- [WireMock extended with Web UI](https://github.com/holomekc/wiremock), a project by [(@holomekc]https://github.com/holomekc)


### PR DESCRIPTION
Just an update towards publishing a new version from the new location

- [x] Update the documentation after moving the repository
- [x] Be explicit about the officialWiremock images and `/holomekc/wiremock-gui`

@gitkent would you mind if I also change the default image to `wiremock/wiremock` while keeping the current one documented?
