### PR TITLE
added imagesecrets, external mappings/requests, args, upd images

### DIFF
--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "2.32.0.2"
+appVersion: "2.35.0.1"
 description: A Helm chart for WireMock deployment on Kubernetes
 name: wiremock
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: "gitkent"
     url: "https://github.com/gitkent"

--- a/charts/wiremock/templates/configmap-mappings.yaml
+++ b/charts/wiremock/templates/configmap-mappings.yaml
@@ -9,9 +9,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+  {{- if .Values.mappings }}
+  {{- toYaml .Values.mappings | nindent 2 }}
+  {{- else }}
   {{- $files := .Files }}
   {{- range $key, $value := .Files }}
   {{- if hasPrefix "mappings/" $key }} {{/* only when in mappings/ */}}
   {{ $key | trimPrefix "mappings/" }}: {{ $files.Get $key | quote }} {{/* adapt $key as desired */}}
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/wiremock/templates/configmap-responses.yaml
+++ b/charts/wiremock/templates/configmap-responses.yaml
@@ -9,9 +9,13 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+  {{- if .Values.responses }}
+  {{- toYaml .Values.responses | nindent 2 }}
+  {{- else }}
   {{- $files := .Files }}
   {{- range $key, $value := .Files }}
   {{- if hasPrefix "responses/" $key }} {{/* only when in responses/ */}}
   {{ $key | trimPrefix "responses/" }}: {{ $files.Get $key | quote }} {{/* adapt $key as desired */}}
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/wiremock/templates/deployment.yaml
+++ b/charts/wiremock/templates/deployment.yaml
@@ -22,10 +22,20 @@ spec:
         app.kubernetes.io/name: {{ include "wiremock.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.flags }}
+          args:
+          {{- range .Values.flags }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.env }}
           env:
           {{- end }}

--- a/charts/wiremock/values.yaml
+++ b/charts/wiremock/values.yaml
@@ -6,8 +6,8 @@ replicaCount: 1
 
 image:
   repository: holomekc/wiremock-gui
-  tag: 2.32.0.2
-  pullPolicy: IfNotPresent
+  tag: 2.35.0.1
+  pullPolicy: Always
 
 initContainer:
   image:
@@ -15,6 +15,7 @@ initContainer:
     tag: 5
     pullPolicy: Always
 
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
@@ -36,8 +37,14 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-env:
-  WIREMOCK_OPTIONS: "--port=9021,--max-request-journal=1000,--local-response-templating,--root-dir=/home/wiremock/storage"
+env: {}
+
+flags: []
+  # - --verbose
+  # - --port=9021
+  # - --max-request-journal=1000
+  # - --local-response-templating
+  # - --root-dir=/home/wiremock/storage
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -58,3 +65,7 @@ tolerations: []
 affinity: {}
 
 scheme: "HTTP"
+
+mappings: {}
+
+responses: {}


### PR DESCRIPTION
# Changelog:
- added `imagePullSecrets` support
- updated images & versions
- added option to specify deployment args, because starting from **2.35.0.1** version `WIREMOCK_OPTION` env variable is deprecated
- added options to mount responses & mappings as a map, in addition to files from chart itself. this is useful when you have something on top of helm chart: helmfile, argo, etc