### PR TITLE
doc(README.md): fix typo at installation and verify steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ in particular [holomekc/wiremock](https://github.com/holomekc/wiremock) with emb
 ## Install WireMock
 
 ```bash
-helm upgrade --install <release_name> ./chart/<chart_name>
+helm upgrade --install <release_name> ./charts/<chart_name>
 ```
 
 Setup port forwarding
@@ -30,7 +30,7 @@ $ kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort}}
 
 ## Verify Wiremock deployment
 
-To verify erifying a response using Wiremock, run
+To verify a response using Wiremock, run
 
 ```bash
 $ curl -X POST http://127.0.0.1:8080/v1/hello


### PR DESCRIPTION
when copying the installation script directly from the README file I got the error due typo in `chart`. so proposing this fix.