### PR TITLE
Update index.yaml

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -6,6 +6,7 @@ entries:
     created: "2023-08-30T15:32:11.9806537+02:00"
     description: A Helm chart for WireMock deployment on Kubernetes
     digest: 23e14af94bbef9fce4a4456f93001ece953cc841a5d2b10dad3075a7a9ba1066
+    name: wiremock
     urls:
     - https://wiremock.github.io/helm-charts/wiremock-0.2.0.tgz
     version: 0.2.0


### PR DESCRIPTION
Without this it's impossible to use v0.2.0 version.

```yaml
apiVersion: v2
name: some
version: 1.0.0
dependencies:
  - name: wiremock
    version: 0.2.0
    repository: https://wiremock.github.io/helm-charts
    condition: wiremock.enabled
```

when running `helm dependency update` below log is printed
```
index.go:370: skipping loading invalid entry for chart "wiremock" "0.2.0" from /Users/klubi/Library/Caches/helm/repository/wiremock-index.yaml: validation: chart.metadata.name is required
Error: can't get a valid version for repositories wiremock. Try changing the version constraint in Chart.yaml
```