### PR TITLE
Update health check paths

### DIFF
--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wiremock/templates/deployment.yaml
+++ b/charts/wiremock/templates/deployment.yaml
@@ -46,12 +46,12 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /__admin/mappings
+              path: /__admin/health
               port: {{ .Values.service.internalPort }}
               scheme: {{ .Values.scheme }}
           readinessProbe:
             httpGet:
-              path: /__admin/mappings
+              path: /__admin/health
               port: {{ .Values.service.internalPort }}
               scheme: {{ .Values.scheme }}
           resources:


### PR DESCRIPTION
WireMock has a system endpoint that can be used to return the health status of the server.
It doesn’t change a lot, but I think it makes "a bit more sense" to use this operation for liveness and readiness probes instead of the current `/__admin/mappings`

https://wiremock.org/docs/standalone/admin-api-reference/#tag/System/operation/getHealth

## References

n/a

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
