### PR TITLE
Support definition of mappings and responses in the values.yaml file

### DIFF
--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wiremock/templates/configmap-mappings.yaml
+++ b/charts/wiremock/templates/configmap-mappings.yaml
@@ -11,3 +11,6 @@ data:
   {{ $key | trimPrefix "mappings/" }}: {{ $files.Get $key | quote }} {{/* adapt $key as desired */}}
   {{- end }}
   {{- end }}
+  {{- with .Values.mappings }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/wiremock/templates/configmap-responses.yaml
+++ b/charts/wiremock/templates/configmap-responses.yaml
@@ -11,3 +11,6 @@ data:
   {{ $key | trimPrefix "responses/" }}: {{ $files.Get $key | quote }} {{/* adapt $key as desired */}}
   {{- end }}
   {{- end }}
+  {{- with .Values.responses }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/wiremock/values.yaml
+++ b/charts/wiremock/values.yaml
@@ -2,6 +2,28 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+mappings: {}
+#  custom_mapping.json: |
+#    {
+#      "request": {
+#        "method": "POST",
+#        "url": "/v1/custom-mapping"
+#      },
+#      "response":{
+#        "status":200,
+#        "bodyFileName":"responses/custom_response.json",
+#        "headers":{
+#          "Content-Type":"application/json"
+#        }
+#      }
+#    }
+
+responses: {}
+#  custom_response.json: |
+#    {
+#      "message": "Here is my custom response!"
+#    }
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
This PR implements the feature requested by @tom-intermedia in the issues #44, meaning it supports the definition of mappings and responses through the `values.yaml` file.

## References

Closes #44 

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

