### PR TITLE
Update HorizontalPodAutoscaler to the v2 CRD

### DIFF
--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.4.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.8.0"
+appVersion: "3.10.0"
 
 maintainers:
   - name: "gitkent"

--- a/charts/wiremock/templates/hpa.yaml
+++ b/charts/wiremock/templates/hpa.yaml
@@ -14,19 +14,19 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - resource:
+    - type: Resource
+      resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-      type: Resource
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - resource:
+    - type: Resource
+      resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-      type: Resource
     {{- end }}
 {{- end }}

--- a/charts/wiremock/templates/hpa.yaml
+++ b/charts/wiremock/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "wiremock.fullname" . }}
@@ -14,15 +14,19 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
+    - resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+      type: Resource
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
+    - resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+      type: Resource
     {{- end }}
 {{- end }}

--- a/charts/wiremock/values.yaml
+++ b/charts/wiremock/values.yaml
@@ -29,7 +29,7 @@ replicaCount: 1
 image:
   repository: wiremock/wiremock
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 3.8.0
+  tag: 3.10.0
   pullPolicy: IfNotPresent
 
 initContainer:


### PR DESCRIPTION
The helm chart fails to apply on "newer" versions of Kubernetes because autoscaling/v2beta is no longer available

## References

https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics

## Submitter checklist

- [ x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ x] The PR request is well described and justified, including the body and the references
- [ x] The PR title represents the desired changelog entry
- [ x] The repository's code style is followed (see the contributing guide)
- [ x] Test coverage that demonstrates that the change works as expected
- [ x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
