### PR TITLE
feat: add extraVolumeMounts and extraVolumes

### DIFF
--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.1
+version: 1.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wiremock/Chart.yaml
+++ b/charts/wiremock/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.2
+version: 1.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wiremock/templates/_helpers.tpl
+++ b/charts/wiremock/templates/_helpers.tpl
@@ -65,14 +65,14 @@ Create the name of the service account to use
 Pod annotations
 */}}
 {{- define "wiremock.podAnnotations" -}}
-{{- if .Values.mappingsAsConfigmap -}}
+{{ if .Values.mappingsAsConfigmap -}}
 checksum/configMappings: {{ include (print $.Template.BasePath "/configmap-mappings.yaml") . | sha256sum }}
-{{- end -}}
-{{- if .Values.responsesAsConfigmap -}}
+{{ end -}}
+{{ if .Values.responsesAsConfigmap -}}
 checksum/configResponses: {{ include (print $.Template.BasePath "/configmap-responses.yaml") . | sha256sum }}
-{{- end -}}
-{{- if .Values.podAnnotations }}
-{{ .Values.podAnnotations }}
+{{ end -}}
+{{ if .Values.podAnnotations -}}
+{{ .Values.podAnnotations | toYaml }}
 {{- end }}
 {{- end }}
 

--- a/charts/wiremock/templates/_helpers.tpl
+++ b/charts/wiremock/templates/_helpers.tpl
@@ -65,8 +65,12 @@ Create the name of the service account to use
 Pod annotations
 */}}
 {{- define "wiremock.podAnnotations" -}}
+{{- if .Values.mappingsAsConfigmap -}}
 checksum/configMappings: {{ include (print $.Template.BasePath "/configmap-mappings.yaml") . | sha256sum }}
+{{- end -}}
+{{- if .Values.responsesAsConfigmap -}}
 checksum/configResponses: {{ include (print $.Template.BasePath "/configmap-responses.yaml") . | sha256sum }}
+{{- end -}}
 {{- if .Values.podAnnotations }}
 {{ .Values.podAnnotations }}
 {{- end }}

--- a/charts/wiremock/templates/_helpers.tpl
+++ b/charts/wiremock/templates/_helpers.tpl
@@ -39,7 +39,13 @@ helm.sh/chart: {{ include "wiremock.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/managed-by: {{ .Release.Service -}}
+{{/*
+Additional labels
+*/}}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -65,14 +71,23 @@ Create the name of the service account to use
 Pod annotations
 */}}
 {{- define "wiremock.podAnnotations" -}}
-{{ if .Values.mappingsAsConfigmap -}}
+{{- if .Values.mappingsAsConfigmap }}
 checksum/configMappings: {{ include (print $.Template.BasePath "/configmap-mappings.yaml") . | sha256sum }}
-{{ end -}}
-{{ if .Values.responsesAsConfigmap -}}
+{{- end }}
+{{- if .Values.responsesAsConfigmap }}
 checksum/configResponses: {{ include (print $.Template.BasePath "/configmap-responses.yaml") . | sha256sum }}
-{{ end -}}
-{{ if .Values.podAnnotations -}}
-{{ .Values.podAnnotations | toYaml }}
+{{- end }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations }}
 {{- end }}
 {{- end }}
 
+{{/*
+Additional Pod Labels
+*/}}
+{{- define "wiremock.podLabels" -}}
+{{ include "wiremock.selectorLabels" . }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}

--- a/charts/wiremock/templates/configmap-mappings.yaml
+++ b/charts/wiremock/templates/configmap-mappings.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mappingsAsConfigmap -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
   {{- with .Values.mappings }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end -}}

--- a/charts/wiremock/templates/configmap-responses.yaml
+++ b/charts/wiremock/templates/configmap-responses.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.responsesAsConfigmap -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
   {{- with .Values.responses }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end -}}

--- a/charts/wiremock/templates/deployment.yaml
+++ b/charts/wiremock/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         {{- include "wiremock.podAnnotations" . | nindent 8 }}
       labels:
-        {{- include "wiremock.selectorLabels" . | nindent 8 }}
+        {{- include "wiremock.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/wiremock/templates/deployment.yaml
+++ b/charts/wiremock/templates/deployment.yaml
@@ -57,11 +57,19 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.mappingsAsConfigmap }}
             - mountPath: /home/wiremock/storage/mappings
               name: mappings-data
+            {{- end }}
+            {{- if .Values.responsesAsConfigmap }}
             - mountPath: /home/wiremock/storage/__files
               name: responses-data
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       initContainers:
+        {{- if .Values.mappingsAsConfigmap }}
         - name: copy-mappings
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -73,6 +81,8 @@ spec:
               name: mappings-volume
             - mountPath: /home/wiremock/storage/mappings
               name: mappings-data
+        {{- end }}
+        {{- if .Values.responsesAsConfigmap }}
         - name: copy-responses
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -84,6 +94,7 @@ spec:
               name: responses-volume
             - mountPath: /home/wiremock/storage/__files
               name: responses-data
+        {{- end }}
         {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -100,13 +111,20 @@ spec:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.mappingsAsConfigmap }}
         - name: mappings-data
-          emptyDir: {}
-        - name: responses-data
           emptyDir: {}
         - name: mappings-volume
           configMap:
             name: {{ include "wiremock.fullname" . }}-mappings-configs
+        {{- end }}
+        {{- if .Values.responsesAsConfigmap }}
+        - name: responses-data
+          emptyDir: {}
         - name: responses-volume
           configMap:
             name: {{ include "wiremock.fullname" . }}-responses-configs
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/wiremock/values.yaml
+++ b/charts/wiremock/values.yaml
@@ -56,23 +56,23 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroupChangePolicy: Always
-  # sysctls: []
-  # supplementalGroups: []
-  # fsGroup: 2000
+#  fsGroupChangePolicy: Always
+#  sysctls: []
+#  supplementalGroups: []
+#  fsGroup: 2000
 
 securityContext: {}
-  # seLinuxOptions: {}
-  # runAsUser: 1000
-  # runAsGroup: 2000
-  # runAsNonRoot: true
-  # privileged: false
-  # readOnlyRootFilesystem: true
-  # allowPrivilegeEscalation: false
-  # capabilities:
-  #   drop: ["ALL"]
-  # seccompProfile:
-  #   type: "RuntimeDefault"
+#  seLinuxOptions: {}
+#  runAsUser: 1000
+#  runAsGroup: 2000
+#  runAsNonRoot: true
+#  privileged: false
+#  readOnlyRootFilesystem: true
+#  allowPrivilegeEscalation: false
+#  capabilities:
+#    drop: ["ALL"]
+#  seccompProfile:
+#    type: "RuntimeDefault"
 
 service:
   type: ClusterIP
@@ -83,8 +83,8 @@ ingress:
   enabled: false
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  #  kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
@@ -103,17 +103,27 @@ args:
   - "--local-response-templating"
   - "--root-dir=/home/wiremock/storage"
 
+# Disable this if you mount your own mappings using extraVolumeMounts
+mappingsAsConfigmap: true
+
+# Disable this if you mount your own responses using extraVolumeMounts
+responsesAsConfigmap: true
+
+extraVolumeMounts: []
+
+extraVolumes: []
+
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
 
 autoscaling:
   enabled: false

--- a/charts/wiremock/values.yaml
+++ b/charts/wiremock/values.yaml
@@ -53,6 +53,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+labels: {}
+
+podLabels: {}
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
The user might want to mount their mappings and responses volumes themselves, in order to get files from other sources such as a PersistentVolume, a S3 bucket, etc. As such, this PR adds `extraVolumeMounts` and `extraVolumes` values, and lets the user disable the default mappings/responses copying from ConfigMap to an emptyDir default behavior. 

## References

- Closes #59 

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
